### PR TITLE
Ramnode/OpenVZ integration

### DIFF
--- a/roles/tinc/tasks/main.yml
+++ b/roles/tinc/tasks/main.yml
@@ -121,4 +121,4 @@
 - name: add nodes to /etc/hosts (ansible_inventory resolves to vpn_ip)
   lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{ hostvars[item].vpn_ip }} {{item}}" state=present
   when: hostvars[item].vpn_ip is defined
-  with_items: groups['all']
+  with_items: "{{ groups['vpn'] }}"

--- a/roles/tinc/tasks/main.yml
+++ b/roles/tinc/tasks/main.yml
@@ -121,4 +121,4 @@
 - name: add nodes to /etc/hosts (ansible_inventory resolves to vpn_ip)
   lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line="{{ hostvars[item].vpn_ip }} {{item}}" state=present
   when: hostvars[item].vpn_ip is defined
-  with_items: "{{ groups['vpn'] }}"
+  with_items: "{{ play_hosts }}"

--- a/roles/tinc/templates/tinc-down.j2
+++ b/roles/tinc/templates/tinc-down.j2
@@ -1,2 +1,2 @@
 #!/bin/sh
-ifconfig $INTERFACE down
+ifconfig {{ vpn_interface }} down

--- a/roles/tinc/templates/tinc-up.j2
+++ b/roles/tinc/templates/tinc-up.j2
@@ -1,2 +1,2 @@
 #!/bin/sh
-ifconfig $INTERFACE {{ vpn_ip }} netmask {{ vpn_netmask }}
+ifconfig {{ vpn_interface }}  {{ vpn_ip }} netmask {{ vpn_netmask }}

--- a/roles/tinc/templates/tinc.conf.j2
+++ b/roles/tinc/templates/tinc.conf.j2
@@ -1,7 +1,7 @@
 Name = {{ inventory_hostname }}
 AddressFamily = ipv4
 Interface = {{ vpn_interface }}
-{% for host in groups['vpn'] %}
+{% for host in play_hosts %}
 {% if inventory_hostname != hostvars[host]['inventory_hostname'] %}
 ConnectTo = {{ hostvars[host]['inventory_hostname'] }}
 {% endif %}

--- a/roles/tinc/templates/tinc.conf.j2
+++ b/roles/tinc/templates/tinc.conf.j2
@@ -1,7 +1,7 @@
 Name = {{ inventory_hostname }}
 AddressFamily = ipv4
 Interface = {{ vpn_interface }}
-{% for host in groups['all'] %}
+{% for host in groups['vpn'] %}
 {% if inventory_hostname != hostvars[host]['inventory_hostname'] %}
 ConnectTo = {{ hostvars[host]['inventory_hostname'] }}
 {% endif %}


### PR DESCRIPTION
While trying to get this working on Ramnode I ran into the issue of the INTERFACE environment variable not being defined. Figured since you already have it in the group vars it can be used from there.

Also, since some of the tasks looped over groups['all'] instead of groups['vpn'] if you had extra hosts groups it would generate tinc config with additional hosts that would not work since tinc had not been installed on them.
