### PR TITLE
fix for "ensure tinc hosts file binds to physical ip address" task

### DIFF
--- a/roles/tinc/tasks/main.yml
+++ b/roles/tinc/tasks/main.yml
@@ -62,6 +62,7 @@
   lineinfile: >
     dest=/etc/tinc/{{ netname }}/hosts/{{ inventory_hostname }}
     line="Address = {{ physical_ip }}"
+    regexp="Address = \d+.\d+.\d+.\d+"
     create=yes
   notify:
     - restart tinc


### PR DESCRIPTION
This fix will help in case then VPS provider has dynamic IPs allocation, for updating host files via replacing old value (without 'regexp' parameter this task will append lines to file).  
