### PR TITLE
added task to install net-tools in RedHat OS family

### DIFF
--- a/roles/tinc/tasks/main.yml
+++ b/roles/tinc/tasks/main.yml
@@ -6,6 +6,12 @@
     state=latest
   when: (ansible_os_family == "RedHat" and ansible_distribution_major_version == "7")
 
+- name: install net-tools
+  package: >
+    name=net-tools
+    state=latest
+  when: (ansible_os_family == "RedHat" and ansible_distribution_major_version == "7")
+
 - name: install tinc
   package: >
     name=tinc


### PR DESCRIPTION
added task to install net-tools in CentOS (in order to provide the ifconfig command used in tinc-up script)